### PR TITLE
Entity w/ ancestor key should load by id.

### DIFF
--- a/src/test/scala/com/meetup/cupboard/tests/QuerySpec.scala
+++ b/src/test/scala/com/meetup/cupboard/tests/QuerySpec.scala
@@ -39,7 +39,6 @@ class QuerySpec extends FunSpec with Matchers with AdHocDatastore {
         // "i eq 3" is scala infix notation for "i.eq(3)"
         val filter = Foo.properties.i eq 3
 
-
         val resultXor = EntityQuery[Foo]()
           .filter(filter)
           .ancestorKey(ancestorKey)


### PR DESCRIPTION
The path segments need to be specified to load an entity by id, which meant
that previously a query could find entities with ancestors but not a direct
load by id.  This adds support for specifying the ancestor path segments.