### PR TITLE
add ancestorPath param to public facing update

### DIFF
--- a/src/main/scala/com/meetup/cupboard/Cupboard.scala
+++ b/src/main/scala/com/meetup/cupboard/Cupboard.scala
@@ -60,16 +60,16 @@ object Cupboard {
    *
    * This will replace the old entity with what you're providing.
    */
-  def update[C](ds: Datastore, caseClass: C, id: Long, kind: String)(implicit cf: DatastoreFormat[C], classtag: ClassTag[C]): Result[C] = {
+  def update[C](ds: Datastore, caseClass: C, id: Long, kind: String, ancestorPath: Seq[(String, Int)])(implicit cf: DatastoreFormat[C], classtag: ClassTag[C]): Result[C] = {
     val key = getKeyWithId(ds, kind, id)
-    updateEntity[C](ds, caseClass, key, kind)
+    updateEntity[C](ds, caseClass, key, kind, ancestorPath)
   }
 
   /**
    * Update an entity with a new value.
    */
-  def update[C](ds: Datastore, caseClass: C, id: Long)(implicit cf: DatastoreFormat[C], typeTag: WeakTypeTag[C], classtag: ClassTag[C]): Result[C] = {
-    update(ds, caseClass, id, getName(typeTag))
+  def update[C](ds: Datastore, caseClass: C, id: Long, ancestorPath: Seq[(String, Int)] = Seq())(implicit cf: DatastoreFormat[C], typeTag: WeakTypeTag[C], classtag: ClassTag[C]): Result[C] = {
+    update(ds, caseClass, id, getName(typeTag), ancestorPath)
   }
 
   def getKey(ds: Datastore, kind: String): Key = {

--- a/src/test/scala/com/meetup/cupboard/tests/MacroDatastoreSpec.scala
+++ b/src/test/scala/com/meetup/cupboard/tests/MacroDatastoreSpec.scala
@@ -45,6 +45,20 @@ class MacroDatastoreSpec extends FunSpec with Matchers with AdHocDatastore {
       }
     }
 
+    it("should support saving and updating with ancestor keys") {
+      withDatastore() { ds =>
+        val f = Foo("test", 3, true)
+        val p = Cupboard.saveWithAncestor(ds, f, "Foo", "Parent", 999)
+        val persistedF = p.getOrElse(fail())
+        val id = persistedF.id
+
+        val updatedF = f.copy(i = 4)
+
+        val updated = Cupboard.update[Foo](ds, updatedF, id, Seq(("Parent", 999)))
+        updated.map(_.entity.i) shouldBe Xor.Right(updatedF.i)
+      }
+    }
+
     it("should support custom kinds") {
       withDatastore() { ds =>
 


### PR DESCRIPTION

Since the private updateEntity method now accepts an ancestorPath in which to look up the entity to update a method by ancestor key, let's also add that param on the public facing update method.