### PR TITLE
Updating the Google Cloud Datastore SDK to 1.98.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.11.8"
 libraryDependencies ++= Seq(
   "io.spray" %%  "spray-json" % "1.3.2",
   "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-  "com.google.cloud" % "google-cloud-datastore" % "0.5.1",
+  "com.google.cloud" % "google-cloud-datastore" % "1.98.0",
   "org.typelevel" %% "cats" % "0.6.0",
   "org.typelevel" %% "macro-compat" % "1.1.1"
 )

--- a/src/main/scala/com/meetup/cupboard/Query.scala
+++ b/src/main/scala/com/meetup/cupboard/Query.scala
@@ -7,8 +7,6 @@ import com.google.cloud.datastore.StructuredQuery.{CompositeFilter, PropertyFilt
 import com.google.cloud.datastore.{QueryResults, EntityQuery => GEntityQuery, Query => GQuery, _}
 import com.meetup.cupboard.datastore.DatastoreProperties
 
-import scala.util.control.NonFatal
-import scala.util.{Either, Left, Right}
 import scala.language.existentials
 
 case class Filter(gfilter: GFilter)
@@ -40,7 +38,7 @@ case class EntityQuery[C](
 
   def resultAsSeq(ds: Datastore): Xor[Throwable, Seq[Persisted[C]]] = {
     val result = runQuery(ds).asScala.map(entity => {
-      val key: Long = entity.key().id()
+      val key: Long = entity.getKey().getId()
       Cupboard.entityToCaseClass(key, entity, cf)
     })
     DatastoreProperties.sequence(result.toList)
@@ -63,12 +61,12 @@ case class EntityQuery[C](
       case None => Cupboard.getName(typeTag)
     }
     val kindedQuery = GQuery
-      .entityQueryBuilder()
-      .kind(kindForQuery)
+      .newEntityQueryBuilder()
+      .setKind(kindForQuery)
 
     val filteredQuery = combineFilters match {
       case None => kindedQuery
-      case Some(filters) => kindedQuery.filter(filters)
+      case Some(filters) => kindedQuery.setFilter(filters)
     }
 
     filteredQuery.build()

--- a/src/test/scala/com/meetup/cupboard/AdHocDatastore.scala
+++ b/src/test/scala/com/meetup/cupboard/AdHocDatastore.scala
@@ -1,7 +1,5 @@
 package com.meetup.cupboard
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.google.cloud.datastore.Datastore
 import com.google.cloud.datastore.testing.LocalDatastoreHelper
 import org.scalatest.Suite
@@ -24,7 +22,7 @@ trait AdHocDatastore extends Suite {
           println("Local datastore created.")
           lds.start()
           println("Local datastore started.")
-          val cached = lds.options().service()
+          val cached = lds.getOptions().getService()
           AdHocDatastore.cachedDatastore = Some(cached)
           AdHocDatastore.count += 1
           cached

--- a/src/test/scala/com/meetup/cupboard/tests/MacroSpec.scala
+++ b/src/test/scala/com/meetup/cupboard/tests/MacroSpec.scala
@@ -4,11 +4,9 @@ import org.scalatest._
 import com.meetup.cupboard.models._
 import com.meetup.cupboard.datastore.DatastoreProperties._
 import com.meetup.cupboard.datastore.DatastoreProperties.InstantDatastoreProperty
-import com.google.cloud.datastore.{DateTime => GDateTime}
 import com.meetup.cupboard.{Persistable, Property}
 import java.time.Instant
 
-import com.google.cloud.datastore.DateTime
 import com.meetup.cupboard.datastore.DatastoreProperty
 import scala.language.reflectiveCalls
 


### PR DESCRIPTION
This is a large jump in the SDK version (0.5.1 to 1.98.0) and required changes to some usages of the SDK. Most of these were superficial name changes. The largest change was the switch from the Google Cloud type `DateTime` to `Timestamp`.

All tests passed without modifications.